### PR TITLE
Drop unnecessary use of Arc wrapping

### DIFF
--- a/src/l1_fetcher.rs
+++ b/src/l1_fetcher.rs
@@ -4,7 +4,6 @@ use rand::random;
 use state_reconstruct::constants::ethereum::{BLOCK_STEP, GENESIS_BLOCK, ZK_SYNC_ADDR};
 use state_reconstruct::parse_calldata;
 use state_reconstruct::CommitBlockInfoV1;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
 
@@ -26,7 +25,7 @@ impl L1Fetcher {
 
     pub async fn fetch(
         &self,
-        sink: mpsc::Sender<Arc<Vec<CommitBlockInfoV1>>>,
+        sink: mpsc::Sender<Vec<CommitBlockInfoV1>>,
         start_block: Option<U64>,
         end_block: Option<U64>,
     ) -> Result<()> {
@@ -72,12 +71,12 @@ impl L1Fetcher {
                     };
                 }
 
-                let tx = match tx {
-                    Some(tx) => Arc::new(tx.input.clone()),
+                let data = match tx {
+                    Some(tx) => tx.input,
                     None => continue,
                 };
 
-                calldata_tx.send(tx).await.unwrap();
+                calldata_tx.send(data).await.unwrap();
             }
         });
 
@@ -91,7 +90,7 @@ impl L1Fetcher {
                     }
                 };
 
-                sink.send(Arc::new(blocks)).await.unwrap();
+                sink.send(blocks).await.unwrap();
             }
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use ethers::types::U64;
 use eyre::Result;
 use l1_fetcher::L1Fetcher;
 use state_reconstruct::CommitBlockInfoV1;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use constants::ethereum;
@@ -59,7 +58,7 @@ async fn main() -> Result<()> {
                 println!("reconstruct from L1, starting from block number {}, processing {} blocks at a time", start_block, block_step);
 
                 let fetcher = L1Fetcher::new(http_url)?;
-                let (tx, mut rx) = mpsc::channel::<Arc<Vec<CommitBlockInfoV1>>>(5);
+                let (tx, mut rx) = mpsc::channel::<Vec<CommitBlockInfoV1>>(5);
                 tokio::spawn(async move {
                     while let Some(blks) = rx.recv().await {
                         blks.iter().for_each(|x| println!("{:?}", x));


### PR DESCRIPTION
After further discussion & experimentation, it turns out that `Arc` was indeed unnecessary.

So let's get rid of it for now :stuck_out_tongue: 