### PR TITLE
Use derive-style `clap`

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.73"
-clap = { version = "4.4.0", features = ["string"] }
+clap = { version = "4.4.0", features = ["derive"] }
 ethers = "1"
 eyre = "0.6.8"
 hex = "0.4.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,39 @@
+use clap::{Parser, Subcommand};
+
+use crate::constants::ethereum;
+
+#[derive(Subcommand)]
+pub enum ReconstructSource {
+    /// Fetch data from L1.
+    L1 {
+        /// The Ethereum JSON-RPC HTTP URL to use.
+        #[arg(long)]
+        http_url: String,
+        /// Ethereum block number to start state import from.
+        #[arg(short, long, default_value_t=ethereum::GENESIS_BLOCK)]
+        start_block: u64,
+        /// The number of blocks to filter & process in one step over.
+        #[arg(short, long, default_value_t=ethereum::BLOCK_STEP)]
+        block_step: u64,
+    },
+    /// Fetch data from a file.
+    File {
+        /// The path of the file to import state from.
+        #[arg(short, long)]
+        file: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Reconstruct L2 state from a source.
+    #[command(subcommand)]
+    Reconstruct(ReconstructSource),
+}
+
+#[derive(Parser)]
+#[command(author, version, about = "zkSync state reconstruction tool")]
+pub struct Args {
+    #[command(subcommand)]
+    pub subcommand: Commands,
+}

--- a/src/l1_fetcher.rs
+++ b/src/l1_fetcher.rs
@@ -1,12 +1,19 @@
-use ethers::abi::Function;
-use ethers::{abi::Contract, prelude::*, providers::Provider};
+use ethers::{
+    abi::{Contract, Function},
+    prelude::*,
+    providers::Provider,
+};
 use eyre::Result;
 use rand::random;
-use tokio::sync::mpsc;
-use tokio::time::{sleep, Duration};
+use tokio::{
+    sync::mpsc,
+    time::{sleep, Duration},
+};
 
-use crate::constants::ethereum::{BLOCK_STEP, GENESIS_BLOCK, ZK_SYNC_ADDR};
-use crate::types::{CommitBlockInfoV1, ParseError};
+use crate::{
+    constants::ethereum::{BLOCK_STEP, GENESIS_BLOCK, ZK_SYNC_ADDR},
+    types::{CommitBlockInfoV1, ParseError},
+};
 
 pub struct L1Fetcher {
     provider: Provider<Http>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(array_chunks)]
 
+mod cli;
 mod constants;
 mod l1_fetcher;
 mod processor;
@@ -7,8 +8,8 @@ mod types;
 
 use std::env;
 
-use clap::{arg, value_parser, Command};
-use constants::ethereum;
+use clap::Parser;
+use cli::*;
 use ethers::types::U64;
 use eyre::Result;
 use l1_fetcher::L1Fetcher;
@@ -19,58 +20,21 @@ use crate::{
     types::CommitBlockInfoV1,
 };
 
-fn cli() -> Command {
-    Command::new("state-reconstruct")
-        .about("zkSync state reconstruction tool")
-        .subcommand_required(true)
-        .arg_required_else_help(false)
-        .subcommand(
-            Command::new("reconstruct")
-                .about("Reconstruct L2 state")
-                .subcommand_required(true)
-                .subcommand(
-                    Command::new("l1")
-                        .about("Read state from Ethereum L1")
-                        .arg(arg!(--"http-url" <HTTP_URL>).help("Ethereum JSON-RPC HTTP URL"))
-                        .arg(
-                            arg!(--"start-block" <START_BLOCK>)
-                                .help("Ethereum block number to start state import from")
-                                .default_value(ethereum::GENESIS_BLOCK.to_string())
-                                .value_parser(value_parser!(u64)),
-                        )
-                        .arg(
-                            arg!(--"block-step" <BLOCK_STEP>)
-                                .help("Number of blocks to filter & process in one step")
-                                .default_value(ethereum::BLOCK_STEP.to_string())
-                                .value_parser(value_parser!(u64)),
-                        ),
-                )
-                .subcommand(
-                    Command::new("file")
-                        .about("Read state from file")
-                        .arg(arg!(<FILE> "File to import state from"))
-                        .arg_required_else_help(true),
-                ),
-        )
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    let matches = cli().get_matches();
+    let args = Args::parse();
 
-    match matches.subcommand() {
-        Some(("reconstruct", sub_matches)) => match sub_matches.subcommand() {
-            Some(("l1", args)) => {
-                // TODO: Use start_block from snapshot.
-                let start_block = args.get_one::<u64>("start-block").expect("required");
-                let block_step = args.get_one::<u64>("block-step").expect("required");
-                let http_url = args.get_one::<String>("http-url").expect("required");
-                println!("reconstruct from L1, starting from block number {}, processing {} blocks at a time", start_block, block_step);
-
+    match args.subcommand {
+        Commands::Reconstruct(subcommand) => match subcommand {
+            ReconstructSource::L1 {
+                http_url,
+                start_block,
+                block_step: _,
+            } => {
                 // TODO: This should be an env variable / CLI argument.
                 let db_dir = env::current_dir()?.join("db");
 
-                let fetcher = L1Fetcher::new(http_url)?;
+                let fetcher = L1Fetcher::new(&http_url)?;
                 let processor = TreeProcessor::new(&db_dir)?;
                 let (tx, rx) = mpsc::channel::<Vec<CommitBlockInfoV1>>(5);
 
@@ -78,15 +42,10 @@ async fn main() -> Result<()> {
                     processor.run(rx).await;
                 });
 
-                fetcher.fetch(tx, Some(U64([*start_block])), None).await?;
+                fetcher.fetch(tx, Some(U64([start_block])), None).await?;
             }
-            Some(("file", args)) => {
-                let input_file = args.get_one::<String>("FILE").expect("required");
-                println!("reconstruct from file (path: \"{}\")", input_file);
-            }
-            _ => unreachable!(),
+            ReconstructSource::File { file: _ } => todo!(),
         },
-        _ => unreachable!(),
     }
 
     Ok(())

--- a/src/processor/tree/mod.rs
+++ b/src/processor/tree/mod.rs
@@ -7,12 +7,9 @@ use async_trait::async_trait;
 use eyre::Result;
 use tokio::sync::mpsc;
 
-use crate::constants::storage::STATE_FILE_PATH;
-use crate::types::CommitBlockInfoV1;
-
 use self::{snapshot::StateSnapshot, tree_wrapper::TreeWrapper};
-
 use super::Processor;
+use crate::{constants::storage::STATE_FILE_PATH, types::CommitBlockInfoV1};
 
 pub struct TreeProcessor<'a> {
     tree: TreeWrapper<'a>,

--- a/src/processor/tree/tree_wrapper.rs
+++ b/src/processor/tree/tree_wrapper.rs
@@ -1,11 +1,10 @@
 use std::{fs, path::Path, str::FromStr};
 
 use ethers::types::{Address, H256, U256};
+use eyre::Result;
 use indexmap::IndexSet;
 use zk_evm::aux_structures::LogQuery;
 use zksync_merkle_tree::{Database, MerkleTree, RocksDBWrapper};
-
-use eyre::Result;
 
 use crate::{constants::storage::INITAL_STATE_PATH, CommitBlockInfoV1};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,8 @@
+use std::vec::Vec;
+
 use ethers::{abi, types::U256};
 use eyre::Result;
 use indexmap::IndexMap;
-use std::vec::Vec;
 use thiserror::Error;
 
 #[allow(clippy::enum_variant_names)]


### PR DESCRIPTION
- Move CLI-arguments to `cli.rs`.
- Use derive-style `clap` instead of builder.
- Introduce common `.rustfmt.toml` settings.