### PR TITLE
feat: db path argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.73"
-clap = { version = "4.4.0", features = ["derive"] }
+clap = { version = "4.4.0", features = ["derive", "env"] }
 ethers = "1"
 eyre = "0.6.8"
 hex = "0.4.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,10 +10,10 @@ pub enum ReconstructSource {
         #[arg(long)]
         http_url: String,
         /// Ethereum block number to start state import from.
-        #[arg(short, long, default_value_t=ethereum::GENESIS_BLOCK)]
+        #[arg(short, long, default_value_t = ethereum::GENESIS_BLOCK)]
         start_block: u64,
         /// The number of blocks to filter & process in one step over.
-        #[arg(short, long, default_value_t=ethereum::BLOCK_STEP)]
+        #[arg(short, long, default_value_t = ethereum::BLOCK_STEP)]
         block_step: u64,
     },
     /// Fetch data from a file.
@@ -25,15 +25,21 @@ pub enum ReconstructSource {
 }
 
 #[derive(Subcommand)]
-pub enum Commands {
+pub enum Command {
     /// Reconstruct L2 state from a source.
-    #[command(subcommand)]
-    Reconstruct(ReconstructSource),
+    Reconstruct {
+        /// The source to fetch data from.
+        #[command(subcommand)]
+        source: ReconstructSource,
+        /// The path to the storage solution.
+        #[arg(short, long, env = "ZK_SYNC_DB_PATH")]
+        db_path: Option<String>,
+    },
 }
 
 #[derive(Parser)]
 #[command(author, version, about = "zkSync state reconstruction tool")]
 pub struct Args {
     #[command(subcommand)]
-    pub subcommand: Commands,
+    pub subcommand: Command,
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,7 +13,9 @@ pub mod storage {
     /// The path to the initial state file.
     pub const INITAL_STATE_PATH: &str = "InitialState.csv";
 
-    // TODO: Configure via env / CLI.
-    /// The path of the state file.
-    pub const STATE_FILE_PATH: &str = "StateSnapshot.json";
+    /// The default name of the database.
+    pub const DEFAULT_DB_NAME: &str = "db";
+
+    /// The name of the state file.
+    pub const STATE_FILE_NAME: &str = "StateSnapshot.json";
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,11 @@ mod l1_fetcher;
 mod processor;
 mod types;
 
-use std::env;
+use std::{env, path::PathBuf};
 
 use clap::Parser;
 use cli::*;
+use constants::storage;
 use ethers::types::U64;
 use eyre::Result;
 use l1_fetcher::L1Fetcher;
@@ -25,27 +26,31 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     match args.subcommand {
-        Commands::Reconstruct(subcommand) => match subcommand {
-            ReconstructSource::L1 {
-                http_url,
-                start_block,
-                block_step: _,
-            } => {
-                // TODO: This should be an env variable / CLI argument.
-                let db_dir = env::current_dir()?.join("db");
+        Command::Reconstruct { source, db_path } => {
+            let db_path = match db_path {
+                Some(path) => PathBuf::from(path),
+                None => env::current_dir()?.join(storage::DEFAULT_DB_NAME),
+            };
 
-                let fetcher = L1Fetcher::new(&http_url)?;
-                let processor = TreeProcessor::new(&db_dir)?;
-                let (tx, rx) = mpsc::channel::<Vec<CommitBlockInfoV1>>(5);
+            match source {
+                ReconstructSource::L1 {
+                    http_url,
+                    start_block,
+                    block_step: _,
+                } => {
+                    let fetcher = L1Fetcher::new(&http_url)?;
+                    let processor = TreeProcessor::new(db_path)?;
+                    let (tx, rx) = mpsc::channel::<Vec<CommitBlockInfoV1>>(5);
 
-                tokio::spawn(async move {
-                    processor.run(rx).await;
-                });
+                    tokio::spawn(async move {
+                        processor.run(rx).await;
+                    });
 
-                fetcher.fetch(tx, Some(U64([start_block])), None).await?;
+                    fetcher.fetch(tx, Some(U64([start_block])), None).await?;
+                }
+                ReconstructSource::File { file: _ } => todo!(),
             }
-            ReconstructSource::File { file: _ } => todo!(),
-        },
+        }
     }
 
     Ok(())

--- a/src/processor/tree/snapshot.rs
+++ b/src/processor/tree/snapshot.rs
@@ -1,4 +1,4 @@
-use std::{fs, io};
+use std::{fs, io, path::Path};
 
 use ethers::types::U256;
 use indexmap::IndexSet;
@@ -15,7 +15,7 @@ pub struct StateSnapshot {
 
 impl StateSnapshot {
     /// Reads and serializes the json file containing the index to key mappings.
-    pub fn read(path: &str) -> Result<StateSnapshot, io::Error> {
+    pub fn read(path: &Path) -> Result<StateSnapshot, io::Error> {
         let contents = fs::read_to_string(path)?;
         let state: StateSnapshot = serde_json::from_str(&contents)?;
 
@@ -23,7 +23,7 @@ impl StateSnapshot {
     }
 
     /// Writes the json file containing the index to key mappings.
-    pub fn write(&self, path: &str) -> Result<(), io::Error> {
+    pub fn write(&self, path: &Path) -> Result<(), io::Error> {
         let content = serde_json::to_string_pretty(&self)?;
         fs::write(path, content)
     }

--- a/src/processor/tree/tree_wrapper.rs
+++ b/src/processor/tree/tree_wrapper.rs
@@ -17,8 +17,8 @@ pub struct TreeWrapper<'a> {
 
 impl TreeWrapper<'static> {
     /// Attempts to create a new [`TreeWrapper`].
-    pub fn new(db_dir: &Path, mut index_to_key_map: IndexSet<U256>) -> Result<Self> {
-        let db = RocksDBWrapper::new(db_dir);
+    pub fn new(db_path: &Path, mut index_to_key_map: IndexSet<U256>) -> Result<Self> {
+        let db = RocksDBWrapper::new(db_path);
         let mut tree = MerkleTree::new(db);
 
         // If an existing `index_to_key` mapping was supplied, use that.


### PR DESCRIPTION
- A new CLI-argument for choosing the path to the database directory.
- Accompanying environment variable for overriding the path: `ZK_SYNC_DB_PATH`.