### PR TITLE
Add support to download from L1 to JSON file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ hex = "0.4.3"
 indexmap = { version = "2.0.1", features = ["serde"] }
 rand = "0.8.0"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = { version = "1.0.107", features = [ "std" ] }
+serde_json_any_key = "2.0.0"
 thiserror = "1.0"
 tokio = { version = "1.32.0", features = ["macros"] }
 zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,20 +1,29 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 use crate::constants::ethereum;
+
+#[derive(Args)]
+pub struct L1FetcherOptions {
+    /// The Ethereum JSON-RPC HTTP URL to use.
+    #[arg(long)]
+    pub http_url: String,
+    /// Ethereum block number to start state import from.
+    #[arg(short, long, default_value_t = ethereum::GENESIS_BLOCK)]
+    pub start_block: u64,
+    /// The number of blocks to filter & process in one step over.
+    #[arg(short, long, default_value_t = ethereum::BLOCK_STEP)]
+    pub block_step: u64,
+    /// The number of blocks to process from Ethereum.
+    #[arg(long)]
+    pub block_count: Option<u64>,
+}
 
 #[derive(Subcommand)]
 pub enum ReconstructSource {
     /// Fetch data from L1.
     L1 {
-        /// The Ethereum JSON-RPC HTTP URL to use.
-        #[arg(long)]
-        http_url: String,
-        /// Ethereum block number to start state import from.
-        #[arg(short, long, default_value_t = ethereum::GENESIS_BLOCK)]
-        start_block: u64,
-        /// The number of blocks to filter & process in one step over.
-        #[arg(short, long, default_value_t = ethereum::BLOCK_STEP)]
-        block_step: u64,
+        #[command(flatten)]
+        args: L1FetcherOptions,
     },
     /// Fetch data from a file.
     File {
@@ -29,18 +38,8 @@ pub enum Command {
     /// Download L2 state from L1 to JSON file.
     #[command(hide = true)]
     Download {
-        /// The Ethereum JSON-RPC HTTP URL to use.
-        #[arg(long)]
-        http_url: String,
-        /// Ethereum block number to start state import from.
-        #[arg(long, default_value_t=ethereum::GENESIS_BLOCK)]
-        start_block: u64,
-        /// The number of blocks to filter & process in one step over.
-        #[arg(long, default_value_t=ethereum::BLOCK_STEP)]
-        block_step: u64,
-        /// The number of blocks to process from Ethereum.
-        #[arg(long)]
-        block_count: Option<u64>,
+        #[command(flatten)]
+        args: L1FetcherOptions,
         /// The path of the file to save the state to.
         file: String,
     },
@@ -58,7 +57,7 @@ pub enum Command {
 
 #[derive(Parser)]
 #[command(author, version, about = "zkSync state reconstruction tool")]
-pub struct Args {
+pub struct Cli {
     #[command(subcommand)]
     pub subcommand: Command,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ pub enum ReconstructSource {
 }
 
 #[derive(Subcommand)]
-pub enum Commands {
+pub enum Command {
     /// Download L2 state from L1 to JSON file.
     #[command(hide = true)]
     Download {
@@ -60,5 +60,5 @@ pub enum Commands {
 #[command(author, version, about = "zkSync state reconstruction tool")]
 pub struct Args {
     #[command(subcommand)]
-    pub subcommand: Commands,
+    pub subcommand: Command,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,25 @@ pub enum Commands {
     /// Reconstruct L2 state from a source.
     #[command(subcommand)]
     Reconstruct(ReconstructSource),
+
+    /// Download L2 state from L1 to JSON file.
+    #[command(hide = true)]
+    Download {
+        /// The Ethereum JSON-RPC HTTP URL to use.
+        #[arg(long)]
+        http_url: String,
+        /// Ethereum block number to start state import from.
+        #[arg(long, default_value_t=ethereum::GENESIS_BLOCK)]
+        start_block: u64,
+        /// The number of blocks to filter & process in one step over.
+        #[arg(long, default_value_t=ethereum::BLOCK_STEP)]
+        block_step: u64,
+        /// The number of blocks to process from Ethereum.
+        #[arg(long)]
+        block_count: Option<u64>,
+        /// The path of the file to save the state to.
+        file: String,
+    },
 }
 
 #[derive(Parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,7 @@ pub enum ReconstructSource {
     /// Fetch data from L1.
     L1 {
         #[command(flatten)]
-        args: L1FetcherOptions,
+        l1_fetcher_options: L1FetcherOptions,
     },
     /// Fetch data from a file.
     File {
@@ -39,7 +39,7 @@ pub enum Command {
     #[command(hide = true)]
     Download {
         #[command(flatten)]
-        args: L1FetcherOptions,
+        l1_fetcher_options: L1FetcherOptions,
         /// The path of the file to save the state to.
         file: String,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,16 +69,12 @@ async fn main() -> Result<()> {
                 processor.run(rx).await;
             });
 
-            let end_block = match block_count {
-                Some(n) => Some(U64([start_block + n])),
-                None => None,
-            };
+            let end_block = block_count.map(|n| U64([start_block + n]));
 
             fetcher
                 .fetch(tx, Some(U64([start_block])), end_block)
                 .await?;
         }
-        _ => unreachable!(),
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,9 @@ use crate::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let cli = Cli::parse();
 
-    match args.subcommand {
+    match cli.subcommand {
         Command::Reconstruct { source, db_path } => {
             let db_path = match db_path {
                 Some(path) => PathBuf::from(path),
@@ -37,9 +37,13 @@ async fn main() -> Result<()> {
 
             match source {
                 ReconstructSource::L1 {
-                    http_url,
-                    start_block,
-                    block_step: _,
+                    args:
+                        L1FetcherOptions {
+                            http_url,
+                            start_block,
+                            block_step: _,
+                            block_count: _,
+                        },
                 } => {
                     let fetcher = L1Fetcher::new(&http_url)?;
                     let processor = TreeProcessor::new(db_path)?;
@@ -55,10 +59,13 @@ async fn main() -> Result<()> {
             }
         }
         Command::Download {
-            http_url,
-            start_block,
-            block_step: _,
-            block_count,
+            args:
+                L1FetcherOptions {
+                    http_url,
+                    start_block,
+                    block_step: _,
+                    block_count,
+                },
             file,
         } => {
             let fetcher = L1Fetcher::new(&http_url)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     match args.subcommand {
-        Commands::Reconstruct { source, db_path } => {
+        Command::Reconstruct { source, db_path } => {
             let db_path = match db_path {
                 Some(path) => PathBuf::from(path),
                 None => env::current_dir()?.join(storage::DEFAULT_DB_NAME),
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
                 ReconstructSource::File { file: _ } => todo!(),
             }
         }
-        Commands::Download {
+        Command::Download {
             http_url,
             start_block,
             block_step: _,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
 
             match source {
                 ReconstructSource::L1 {
-                    args:
+                    l1_fetcher_options:
                         L1FetcherOptions {
                             http_url,
                             start_block,
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
             }
         }
         Command::Download {
-            args:
+            l1_fetcher_options:
                 L1FetcherOptions {
                     http_url,
                     start_block,

--- a/src/processor/json/mod.rs
+++ b/src/processor/json/mod.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+use eyre::Result;
+use serde::ser::{SerializeSeq, Serializer};
+use serde_json;
+use std::{fs::File, path::Path};
+use tokio::sync::mpsc;
+
+use crate::types::CommitBlockInfoV1;
+
+use super::Processor;
+
+pub struct JsonSerializationProcessor {
+    serializer: serde_json::Serializer<File>,
+}
+
+impl JsonSerializationProcessor {
+    pub fn new(out_file: &Path) -> Result<Self> {
+        let file = File::create(out_file)?;
+        let serializer = serde_json::Serializer::new(file);
+        Ok(Self { serializer })
+    }
+}
+
+#[async_trait]
+impl Processor for JsonSerializationProcessor {
+    async fn run(mut self, mut rx: mpsc::Receiver<Vec<CommitBlockInfoV1>>) {
+        let mut seq = self
+            .serializer
+            .serialize_seq(None)
+            .expect("serializer construction failed");
+        while let Some(blocks) = rx.recv().await {
+            for block in blocks {
+                seq.serialize_element(&block).expect("block serialization");
+            }
+        }
+        seq.end().expect("JSON array closing");
+    }
+}

--- a/src/processor/json/mod.rs
+++ b/src/processor/json/mod.rs
@@ -1,13 +1,13 @@
+use std::{fs::File, path::Path};
+
 use async_trait::async_trait;
 use eyre::Result;
 use serde::ser::{SerializeSeq, Serializer};
 use serde_json;
-use std::{fs::File, path::Path};
 use tokio::sync::mpsc;
 
-use crate::types::CommitBlockInfoV1;
-
 use super::Processor;
+use crate::types::CommitBlockInfoV1;
 
 pub struct JsonSerializationProcessor {
     serializer: serde_json::Serializer<File>,

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -3,6 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::types::CommitBlockInfoV1;
 
+pub mod json;
 pub mod tree;
 
 #[async_trait]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,8 @@ use std::vec::Vec;
 use ethers::{abi, types::U256};
 use eyre::Result;
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use serde_json_any_key::*;
 use thiserror::Error;
 
 #[allow(clippy::enum_variant_names)]
@@ -22,7 +24,7 @@ pub enum ParseError {
 }
 
 /// Data needed to commit new block
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CommitBlockInfoV1 {
     /// L2 block number.
     pub block_number: u64,
@@ -39,8 +41,10 @@ pub struct CommitBlockInfoV1 {
     /// Hash of all priority operations from this block.
     pub priority_operations_hash: Vec<u8>,
     /// Storage write access as a concatenation key-value.
+    #[serde(with = "any_key_map")]
     pub initial_storage_changes: IndexMap<[u8; 32], [u8; 32]>,
     /// Storage write access as a concatenation index-value.
+    #[serde(with = "any_key_map")]
     pub repeated_storage_changes: IndexMap<u64, [u8; 32]>,
     /// Concatenation of all L2 -> L1 logs in the block.
     pub l2_logs: Vec<u8>,


### PR DESCRIPTION
This change adds hidden `download` command that can be used to download L2 state from L1 and save it into JSON file in pre-processed format.

The JSON serialization format is first iteration and not optimized yet.