### PR TITLE
Reveal `download` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,7 +44,6 @@ pub enum Query {
 #[derive(Subcommand)]
 pub enum Command {
     /// Download L2 state from L1 to JSON file.
-    #[command(hide = true)]
     Download {
         #[command(flatten)]
         l1_fetcher_options: L1FetcherOptions,


### PR DESCRIPTION
Originally `download` command was only meant for development testing, but it seems to be useful for other means as well, so this change will reveal it publicly in `help` print.