### PR TITLE
ref: include batch number in root hash query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use clap::Parser;
-use cli::{Cli, Command, Query, ReconstructSource};
+use cli::{Cli, Command, ReconstructSource};
 use constants::storage;
 use eyre::Result;
 use snapshot::StateSnapshot;
@@ -131,9 +131,7 @@ async fn main() -> Result<()> {
             };
 
             let tree = QueryTree::new(&db_path);
-            let result = match query {
-                Query::RootHash => tree.latest_root_hash(),
-            };
+            let result = tree.query(&query);
 
             if json {
                 println!("{}", serde_json::to_string(&result)?);


### PR DESCRIPTION
New output:
```fish
Batch: 12
Root Hash: d1fe897f75c4c90e9555028df17556dc0afd9e9d4369899a8ae9a50178773dab
```

With `--json`:
```fish
{"batch":12,"root_hash":"d1fe897f75c4c90e9555028df17556dc0afd9e9d4369899a8ae9a50178773dab"}
```