### PR TITLE
feat: initial export snapshot skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,6 +4631,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "blake2 0.10.6",
+ "chrono",
  "clap 4.4.7",
  "ethers",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = ["state-reconstruct-fetcher"]
 [dependencies]
 async-trait = "0.1.74"
 blake2 = "0.10.6"
+chrono = "0.4.31"
 clap = { version = "4.4.7", features = ["derive", "env"] }
 ethers = "1.0.2"
 eyre = "0.6.8"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,14 @@ pub enum Command {
         #[arg(short, long, env = "ZK_SYNC_DB_PATH")]
         db_path: Option<String>,
     },
+
+    /// Testing.
+    ExportSnapshot {
+        #[command(flatten)]
+        l1_fetcher_options: L1FetcherOptions,
+        /// The path of the file to export the snapshot to.
+        file: Option<String>,
+    },
 }
 
 #[derive(Parser)]

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -3,9 +3,10 @@ use state_reconstruct_fetcher::types::CommitBlockInfoV1;
 use tokio::sync::mpsc;
 
 pub mod json;
+pub mod snapshot;
 pub mod tree;
 
 #[async_trait]
 pub trait Processor {
-    async fn run(self, rx: mpsc::Receiver<CommitBlockInfoV1>);
+    async fn run(self, mut rx: mpsc::Receiver<CommitBlockInfoV1>);
 }

--- a/src/processor/snapshot/mod.rs
+++ b/src/processor/snapshot/mod.rs
@@ -67,8 +67,7 @@ impl fmt::Display for SnapshotExporter {
 #[async_trait]
 impl Processor for SnapshotExporter {
     async fn run(mut self, mut rx: mpsc::Receiver<CommitBlockInfoV1>) {
-        // TODO: Send these from fetcher.
-        let miniblock_number = U64::from(0);
+        // TODO: Send from fetcher.
         let l1_block_number = U64::from(0);
 
         while let Some(block) = rx.recv().await {
@@ -84,7 +83,8 @@ impl Processor for SnapshotExporter {
                     .or_insert(SnapshotStorageLog {
                         key,
                         value: StorageValue::default(),
-                        miniblock_number_of_initial_write: miniblock_number,
+                        // NOTE: This isn't stored in L1, can we procure it some other way?
+                        miniblock_number_of_initial_write: U64::from(0),
                         l1_batch_number_of_initial_write: l1_block_number,
                         enumeration_index: 0,
                     });

--- a/src/processor/snapshot/types.rs
+++ b/src/processor/snapshot/types.rs
@@ -1,0 +1,74 @@
+// FIXME:
+#![allow(dead_code)]
+use std::fmt;
+
+use chrono::{offset::Utc, DateTime};
+use ethers::types::{H256, U256, U64};
+
+pub type L1BatchNumber = U64;
+pub type MiniblockNumber = U64;
+
+pub type StorageKey = U256;
+pub type StorageValue = H256;
+
+#[derive(Default, Debug)]
+pub struct SnapshotHeader {
+    pub l1_batch_number: L1BatchNumber,
+    pub miniblock_number: MiniblockNumber,
+    /// Chunk metadata ordered by chunk_id
+    pub chunks: Vec<SnapshotChunkMetadata>,
+    // TODO:
+    // pub last_l1_batch_with_metadata: L1BatchWithMetadata,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Default, Debug)]
+pub struct SnapshotChunkMetadata {
+    pub key: SnapshotStorageKey,
+    /// Can be either a gs or filesystem path
+    pub filepath: String,
+}
+
+#[derive(Default, Debug)]
+pub struct SnapshotStorageKey {
+    pub l1_batch_number: L1BatchNumber,
+    /// Chunks with smaller id's must contain storage_logs with smaller hashed_keys
+    pub chunk_id: u64,
+}
+
+#[derive(Default, Debug)]
+pub struct SnapshotChunk {
+    // Sorted by hashed_keys interpreted as little-endian numbers
+    pub storage_logs: Vec<SnapshotStorageLog>,
+    pub factory_deps: Vec<SnapshotFactoryDependency>,
+}
+
+// "most recent" for each key together with info when the key was first used
+#[derive(Default, Debug)]
+pub struct SnapshotStorageLog {
+    pub key: StorageKey,
+    pub value: StorageValue,
+    pub miniblock_number_of_initial_write: MiniblockNumber,
+    pub l1_batch_number_of_initial_write: L1BatchNumber,
+    pub enumeration_index: u64,
+}
+
+impl fmt::Display for SnapshotStorageLog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{},{},{},{},{}",
+            self.key,
+            hex::encode(self.value),
+            self.miniblock_number_of_initial_write,
+            self.l1_batch_number_of_initial_write,
+            self.enumeration_index
+        )
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct SnapshotFactoryDependency {
+    pub bytecode_hash: H256,
+    pub bytecode: Vec<u8>,
+}


### PR DESCRIPTION
Implements a skeleton of the export snapshot functionality.

Currently only handles the partial exporting of storage logs. Storage logs processing are missing handling of `enumeration_index` & `L1Metadata` that needs to be procured through the fetcher.