### PR TITLE
ci: adjust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
         checks: [
           fmt --all --check,
           check --all-targets --all-features,
-          clippy --all-targets --all-features,
-          test
+          clippy --all-targets --all-features -- -D warnings,
+          test --all-targets --all-features
         ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The clippy check wasn't failing on warnings, this PR fixes that along with adjusting the test check.