### PR TITLE
tweak: store the last processed block in snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,6 +5078,7 @@ dependencies = [
  "serde_json_any_key",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/state-reconstruct-fetcher/Cargo.toml
+++ b/state-reconstruct-fetcher/Cargo.toml
@@ -13,4 +13,5 @@ serde_json = { version = "1.0.107", features = ["std"] }
 serde_json_any_key = "2.0.0"
 thiserror = "1.0.50"
 tokio = { version = "1.33.0", features = ["signal"] }
+tokio-util = "0.7.10"
 tracing = "0.1.40"


### PR DESCRIPTION
Before, we stored the last fetched block and waited until it had processed fully before terminating the main fetching loop. When the fetcher would repeatedly fail to procure a transaction, it would also delay the shutdown process. This change updates the snapshot with the last *processed* block instead.