### PR TITLE
doc: clarify flake availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Currently there are three ways to setup the environment: using the provided Nix flake, the container image, or installing the dependencies manually.
 
 <details>
-  <summary>Nix Flake</summary>
+  <summary>Nix Flake (Linux only)</summary>
   To use the supplied Nix development environment you need to have Nix installed, This can be done by following the official instructions <a href="https://nixos.org/download.html">here</a>.   <br><br>
 
   Once Nix is installed, the development environment can be activated via the following command:

--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,10 @@
     nixpkgs,
     rust-overlay,
     flake-utils,
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
+  }: let
+    supportedSystems = ["x86_64-linux"];
+  in
+    flake-utils.lib.eachSystem supportedSystems (system: let
       overlays = [(import rust-overlay)];
       pkgs = import nixpkgs {inherit system overlays;};
       rust-toolchain =


### PR DESCRIPTION
- Clarify that we only support using the Nix flake on Linux systems
- Closes #55 