### PR TITLE
ignoring send error during shutdown

### DIFF
--- a/state-reconstruct-fetcher/src/l1_fetcher.rs
+++ b/state-reconstruct-fetcher/src/l1_fetcher.rs
@@ -256,7 +256,18 @@ impl L1Fetcher {
                             }
 
                             if let Some(tx_hash) = log.transaction_hash {
-                                hash_tx.send(tx_hash).await.unwrap();
+                                match hash_tx.send(tx_hash).await {
+                                    Err(e) => {
+                                        if cancellation_token.is_cancelled() {
+                                            tracing::debug!("Shutting down...");
+                                            break;
+                                        } else {
+                                            tracing::error!("Cannot send tx hash: {e}");
+                                            continue;
+                                        }
+                                    }
+                                    _ => (),
+                                }
                             }
 
                             latest_l2_block_number = new_l2_block_number;

--- a/state-reconstruct-fetcher/src/l1_fetcher.rs
+++ b/state-reconstruct-fetcher/src/l1_fetcher.rs
@@ -258,7 +258,7 @@ impl L1Fetcher {
                             if let Some(tx_hash) = log.transaction_hash {
                                 if let Err(e) = hash_tx.send(tx_hash).await {
                                     if cancellation_token.is_cancelled() {
-                                        tracing::debug!("Shutting down...");
+                                        tracing::debug!("Shutting down tx sender...");
                                         break;
                                     } else {
                                         tracing::error!("Cannot send tx hash: {e}");

--- a/state-reconstruct-fetcher/src/l1_fetcher.rs
+++ b/state-reconstruct-fetcher/src/l1_fetcher.rs
@@ -256,17 +256,14 @@ impl L1Fetcher {
                             }
 
                             if let Some(tx_hash) = log.transaction_hash {
-                                match hash_tx.send(tx_hash).await {
-                                    Err(e) => {
-                                        if cancellation_token.is_cancelled() {
-                                            tracing::debug!("Shutting down...");
-                                            break;
-                                        } else {
-                                            tracing::error!("Cannot send tx hash: {e}");
-                                            continue;
-                                        }
+                                if let Err(e) = hash_tx.send(tx_hash).await {
+                                    if cancellation_token.is_cancelled() {
+                                        tracing::debug!("Shutting down...");
+                                        break;
+                                    } else {
+                                        tracing::error!("Cannot send tx hash: {e}");
+                                        continue;
                                     }
-                                    _ => (),
                                 }
                             }
 


### PR DESCRIPTION
Occasionally, the program doesn't end cleanly when interrupted. This is a fix for an especially common error:
```
thread 'tokio-runtime-worker' panicked at state-reconstruct-fetcher/src/l1_fetcher.rs:259:61:
called `Result::unwrap()` on an `Err` value: SendError { .. }
```
The error in this case being "channel closed", as the receiver apparently shut down first.