### PR TITLE
tweak: adjust how metrics are collected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ target/
 *.pdb
 
 # Local state files.
-db/
+db*/
 snapshot_db/
 StateSnapshot.json
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,8 @@ async fn main() -> Result<()> {
 
             fetcher.run(tx).await?;
             processor_handle.await?;
+
+            tracing::info!("Successfully downloaded CommitBlocks to {}", file);
         }
         Command::Query {
             query,

--- a/state-reconstruct-fetcher/src/l1_fetcher.rs
+++ b/state-reconstruct-fetcher/src/l1_fetcher.rs
@@ -79,7 +79,7 @@ impl L1Fetcher {
         let v2 = Contract::load(File::open("./abi/IZkSyncV2.json")?)?;
         let contracts = Contracts { v1, v2 };
 
-        let metrics = Arc::new(Mutex::new(L1Metrics::default()));
+        let metrics = Arc::new(Mutex::new(L1Metrics::new(config.start_block)));
 
         Ok(L1Fetcher {
             provider,
@@ -128,10 +128,13 @@ impl L1Fetcher {
         {
             let mut metrics = self.metrics.lock().await;
             metrics.last_l1_block = end_block_number.as_u64();
-            metrics.first_l1_block = current_l1_block_number.as_u64();
-            metrics.latest_l1_block_nbr = current_l1_block_number.as_u64();
+            metrics.initial_l1_block = self.config.start_block;
+            metrics.first_l1_block_num = current_l1_block_number.as_u64();
+            metrics.latest_l1_block_num = current_l1_block_number.as_u64();
             if let Some(snapshot) = &self.snapshot {
-                metrics.latest_l2_block_nbr = snapshot.lock().await.latest_l2_block_number;
+                let snapshot = snapshot.lock().await;
+                metrics.latest_l2_block_num = snapshot.latest_l2_block_number;
+                metrics.first_l2_block_num = snapshot.latest_l2_block_number;
             }
         }
 
@@ -160,7 +163,7 @@ impl L1Fetcher {
         // If an `end_block` was supplied we shouldn't poll for newer blocks.
         let mut disable_polling = self.config.disable_polling;
         if end_block.is_some() {
-            disable_polling = false;
+            disable_polling = true;
         }
 
         // Split L1 block processing into three async steps:
@@ -184,17 +187,18 @@ impl L1Fetcher {
 
         tx_handle.await?;
         let last_processed_l1_block_num = parse_handle.await?;
-        main_handle.await?;
+        let last_fetched_l1_block_num = main_handle.await?;
 
         // Store our current L1 block number so we can resume from where we left
         // off, we also make sure to update the metrics before printing them.
         if let Some(block_num) = last_processed_l1_block_num {
-            self.metrics.lock().await.latest_l1_block_nbr = block_num;
             if let Some(snapshot) = &self.snapshot {
                 snapshot.lock().await.latest_l1_block_number = U64::from(block_num);
             }
         }
-        self.metrics.lock().await.print();
+        let mut metrics = self.metrics.lock().await;
+        metrics.latest_l1_block_num = last_fetched_l1_block_num;
+        metrics.print();
 
         Ok(())
     }
@@ -206,7 +210,7 @@ impl L1Fetcher {
         mut current_l1_block_number: U64,
         end_block_number: U64,
         disable_polling: bool,
-    ) -> Result<tokio::task::JoinHandle<()>> {
+    ) -> Result<tokio::task::JoinHandle<u64>> {
         let metrics = self.metrics.clone();
         let event = self.contracts.v1.events_by_name("BlockCommit")?[0].clone();
         let provider_clone = self.provider.clone();
@@ -274,11 +278,13 @@ impl L1Fetcher {
                         continue;
                     };
 
-                    metrics.lock().await.latest_l1_block_nbr = current_l1_block_number.as_u64();
+                    metrics.lock().await.latest_l1_block_num = current_l1_block_number.as_u64();
 
                     // Increment current block index.
                     current_l1_block_number += BLOCK_STEP.into();
                 }
+
+                current_l1_block_number.as_u64()
             }
         }))
     }
@@ -331,8 +337,7 @@ impl L1Fetcher {
                     if let Some(current_block) = tx.block_number {
                         let current_block = current_block.as_u64();
                         if last_block < current_block {
-                            let mut metrics = metrics.lock().await;
-                            metrics.l1_blocks_processed += current_block - last_block;
+                            metrics.lock().await.latest_l1_block_num = current_block;
                             last_block = current_block;
                         }
                     }
@@ -343,8 +348,6 @@ impl L1Fetcher {
         })
     }
 
-    // FIXME:
-    #[allow(clippy::absurd_extreme_comparisons)]
     fn spawn_parsing_handler(
         &self,
         mut l1_tx_rx: mpsc::Receiver<Transaction>,
@@ -378,17 +381,15 @@ impl L1Fetcher {
                         }
                     };
 
+                    let mut metrics = metrics.lock().await;
                     for blk in blocks {
-                        // NOTE: Let's see if we want to increment this in batches, instead of each block individually.
-                        let mut metrics = metrics.lock().await;
-                        metrics.l2_blocks_processed += 1;
-                        metrics.latest_l2_block_nbr = blk.l2_block_number;
+                        metrics.latest_l2_block_num = blk.l2_block_number;
                         sink.send(blk).await.unwrap();
                     }
 
                     last_block_number_processed = block_number;
                     let duration = before.elapsed();
-                    metrics.lock().await.parsing.add(duration);
+                    metrics.parsing.add(duration);
                 }
 
                 // Return the last processed l1 block number, so we can resume from the same point later on.

--- a/state-reconstruct-fetcher/src/metrics.rs
+++ b/state-reconstruct-fetcher/src/metrics.rs
@@ -4,31 +4,84 @@ use tokio::time::Duration;
 
 pub const METRICS_TRACING_TARGET: &str = "metrics";
 
+pub struct L1Metrics {
+    /// The first L1 block fetched.
+    pub first_l1_block_num: u64,
+    /// The first L2 block fetched.
+    pub first_l2_block_num: u64,
+
+    /// The latest L1 block fetched.
+    pub latest_l1_block_num: u64,
+    /// The latest L2 block fetched.
+    pub latest_l2_block_num: u64,
+
+    /// The first L1 block to compare against when measuring progress.
+    pub initial_l1_block: u64,
+    /// The last L1 block to compare against when measuring progress.
+    pub last_l1_block: u64,
+
+    /// Time taken to procure a log from L1.
+    pub log_acquisition: PerfMetric,
+    /// Time taken to procure a transaction from L1.
+    pub tx_acquisition: PerfMetric,
+    /// Time taken to parse a [`CommitBlockInfo`] from a transaction.
+    pub parsing: PerfMetric,
+}
+
+impl L1Metrics {
+    pub fn new(initial_l1_block: u64) -> Self {
+        L1Metrics {
+            first_l1_block_num: 0,
+            first_l2_block_num: 0,
+            latest_l1_block_num: 0,
+            latest_l2_block_num: 0,
+            initial_l1_block,
+            last_l1_block: 0,
+            log_acquisition: PerfMetric::new("log_acquisition"),
+            tx_acquisition: PerfMetric::new("tx_acquisition"),
+            parsing: PerfMetric::new("parsing"),
+        }
+    }
+    pub fn print(&mut self) {
+        if self.latest_l1_block_num == 0 {
+            return;
+        }
+
+        let progress = {
+            let total = self.last_l1_block - self.initial_l1_block;
+            let cur = self.latest_l1_block_num - self.initial_l1_block;
+            // If polling past `last_l1_block`, stop at 100%.
+            let perc = std::cmp::min((cur * 100) / total, 100);
+            format!("{perc:>2}%")
+        };
+
+        tracing::info!(
+            "PROGRESS: [{}] CUR BLOCK L1: {} L2: {} TOTAL BLOCKS PROCESSED L1: {} L2: {}",
+            progress,
+            self.latest_l1_block_num,
+            self.latest_l2_block_num,
+            self.latest_l1_block_num - self.first_l1_block_num,
+            self.latest_l2_block_num - self.first_l2_block_num
+        );
+
+        let log_acquisition = self.log_acquisition.reset();
+        let tx_acquisition = self.tx_acquisition.reset();
+        let parsing = self.parsing.reset();
+        tracing::debug!(
+            target: METRICS_TRACING_TARGET,
+            "ACQUISITION: avg log {} tx {} parse {}",
+            log_acquisition,
+            tx_acquisition,
+            parsing
+        );
+    }
+}
+
 /// Average, explicitly resettable time used by a specific (named) operation.
 pub struct PerfMetric {
     name: String,
     total: Duration,
     count: u32,
-}
-
-pub struct L1Metrics {
-    // Metrics variables.
-    pub l1_blocks_processed: u64,
-    pub l2_blocks_processed: u64,
-    pub latest_l1_block_nbr: u64,
-    pub latest_l2_block_nbr: u64,
-
-    pub first_l1_block: u64,
-    pub last_l1_block: u64,
-
-    /// Time taken to procure a log from L1.
-    pub log_acquisition: PerfMetric,
-
-    /// Time taken to procure a transaction from L1.
-    pub tx_acquisition: PerfMetric,
-
-    /// Time taken to parse a [`CommitBlockInfo`] from a transaction.
-    pub parsing: PerfMetric,
 }
 
 impl PerfMetric {
@@ -63,57 +116,5 @@ impl fmt::Display for PerfMetric {
             let duration = self.total / self.count;
             write!(f, "{:?}", duration)
         }
-    }
-}
-
-impl Default for L1Metrics {
-    fn default() -> Self {
-        L1Metrics {
-            l1_blocks_processed: 0,
-            l2_blocks_processed: 0,
-            latest_l1_block_nbr: 0,
-            latest_l2_block_nbr: 0,
-            first_l1_block: 0,
-            last_l1_block: 0,
-            log_acquisition: PerfMetric::new("log_acquisition"),
-            tx_acquisition: PerfMetric::new("tx_acquisition"),
-            parsing: PerfMetric::new("parsing"),
-        }
-    }
-}
-
-impl L1Metrics {
-    pub fn print(&mut self) {
-        if self.latest_l1_block_nbr == 0 {
-            return;
-        }
-
-        let progress = {
-            let total = self.last_l1_block - self.first_l1_block;
-            let cur = self.latest_l1_block_nbr - self.first_l1_block;
-            // If polling past `last_l1_block`, stop at 100%.
-            let perc = std::cmp::min((cur * 100) / total, 100);
-            format!("{perc:>2}%")
-        };
-
-        let log_acquisition = self.log_acquisition.reset();
-        let tx_acquisition = self.tx_acquisition.reset();
-        let parsing = self.parsing.reset();
-
-        tracing::info!(
-            "PROGRESS: [{}] CUR BLOCK L1: {} L2: {} TOTAL BLOCKS PROCESSED L1: {} L2: {}",
-            progress,
-            self.latest_l1_block_nbr,
-            self.latest_l2_block_nbr,
-            self.l1_blocks_processed,
-            self.l2_blocks_processed
-        );
-        tracing::debug!(
-            target: METRICS_TRACING_TARGET,
-            "ACQUISITION: avg log {} tx {} parse {}",
-            log_acquisition,
-            tx_acquisition,
-            parsing
-        );
     }
 }


### PR DESCRIPTION
- Instead of incrementing `*_blocks_processed` calculate the number of blocks by comparing the current block number with the block number the tool was started on. This also fixes an issue that was present earlier, where the number of blocks processed was inflated and not accurately represented on first launch.
- The percentage calculation is now based on total progress from the genesis block (or `start_block` if that's been supplied) instead of total progress from the last stored block.