### PR TITLE
ref: abstract away protobuf from snapshot

### DIFF
--- a/src/processor/snapshot/mod.rs
+++ b/src/processor/snapshot/mod.rs
@@ -3,9 +3,9 @@ use std::{fs, path::PathBuf, str::FromStr};
 pub mod database;
 pub mod exporter;
 pub mod importer;
+pub mod types;
 
 mod bytecode;
-mod types;
 
 use async_trait::async_trait;
 use blake2::{Blake2s256, Digest};
@@ -27,6 +27,10 @@ use crate::processor::snapshot::types::MiniblockNumber;
 pub const DEFAULT_DB_PATH: &str = "snapshot_db";
 pub const SNAPSHOT_HEADER_FILE_NAME: &str = "snapshot-header.json";
 pub const SNAPSHOT_FACTORY_DEPS_FILE_NAME_SUFFIX: &str = "factory_deps.proto.gzip";
+
+pub mod protobuf {
+    include!(concat!(env!("OUT_DIR"), "/protobuf.rs"));
+}
 
 pub struct SnapshotBuilder {
     database: SnapshotDB,

--- a/src/processor/snapshot/types.rs
+++ b/src/processor/snapshot/types.rs
@@ -1,14 +1,73 @@
-use std::fmt;
+use std::{
+    io::{Read, Write},
+    path::Path,
+};
 
+use bytes::BytesMut;
 use chrono::{offset::Utc, DateTime};
 use ethers::types::{H256, U256, U64};
+use eyre::Result;
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use prost::Message;
 use serde::{Deserialize, Serialize};
+
+use super::{bytecode, protobuf};
 
 pub type L1BatchNumber = U64;
 pub type MiniblockNumber = U64;
 
 pub type StorageKey = U256;
 pub type StorageValue = H256;
+
+pub trait Proto {
+    type ProtoStruct: Message + Default;
+
+    /// Convert [`Self`] into its protobuf generated equivalent.
+    fn to_proto(&self) -> Self::ProtoStruct;
+
+    /// Convert from a generated protobuf struct.
+    fn from_proto(proto: Self::ProtoStruct) -> Result<Self>
+    where
+        Self: Sized;
+
+    /// Encode [`Self`] to file using gzip compression.
+    fn encode(&self, path: &Path) -> Result<()> {
+        let proto = Self::to_proto(self);
+
+        // Ensure that write buffer has enough capacity.
+        let mut buf = BytesMut::new();
+        let len = proto.encoded_len();
+        if buf.capacity() < len {
+            buf.reserve(len - buf.capacity());
+        }
+
+        Self::ProtoStruct::encode(&proto, &mut buf)?;
+        let outfile = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+
+        let mut encoder = GzEncoder::new(outfile, Compression::default());
+        encoder.write_all(&buf)?;
+        encoder.finish()?;
+
+        Ok(())
+    }
+
+    /// Decode a slice of gzip-compressed bytes into [`Self`].
+    fn decode(bytes: &[u8]) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut decoder = GzDecoder::new(bytes);
+        let mut decompressed_bytes = Vec::new();
+        decoder.read_to_end(&mut decompressed_bytes)?;
+
+        let proto = Self::ProtoStruct::decode(&decompressed_bytes[..])?;
+        Self::from_proto(proto)
+    }
+}
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct SnapshotHeader {
@@ -37,10 +96,32 @@ pub struct SnapshotStorageKey {
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
-pub struct SnapshotChunk {
-    // Sorted by `hashed_keys` interpreted as little-endian numbers
+pub struct SnapshotStorageLogsChunk {
     pub storage_logs: Vec<SnapshotStorageLog>,
-    pub factory_deps: Vec<SnapshotFactoryDependency>,
+}
+
+impl Proto for SnapshotStorageLogsChunk {
+    type ProtoStruct = protobuf::SnapshotStorageLogsChunk;
+
+    fn to_proto(&self) -> Self::ProtoStruct {
+        Self::ProtoStruct {
+            storage_logs: self
+                .storage_logs
+                .iter()
+                .map(SnapshotStorageLog::to_proto)
+                .collect(),
+        }
+    }
+
+    fn from_proto(proto: Self::ProtoStruct) -> Result<Self> {
+        Ok(Self {
+            storage_logs: proto
+                .storage_logs
+                .into_iter()
+                .map(SnapshotStorageLog::from_proto)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
 }
 
 // "most recent" for each key together with info when the key was first used
@@ -53,17 +134,60 @@ pub struct SnapshotStorageLog {
     pub enumeration_index: u64,
 }
 
-impl fmt::Display for SnapshotStorageLog {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{},{},{},{},{}",
-            self.key,
-            hex::encode(self.value),
-            self.miniblock_number_of_initial_write,
-            self.l1_batch_number_of_initial_write,
-            self.enumeration_index
-        )
+impl Proto for SnapshotStorageLog {
+    type ProtoStruct = protobuf::SnapshotStorageLog;
+
+    fn to_proto(&self) -> Self::ProtoStruct {
+        let mut key = [0u8; 32];
+        self.key.to_big_endian(&mut key);
+
+        Self::ProtoStruct {
+            account_address: None,
+            storage_key: Some(key.to_vec()),
+            storage_value: Some(self.value.as_bytes().to_vec()),
+            l1_batch_number_of_initial_write: Some(self.l1_batch_number_of_initial_write.as_u32()),
+            enumeration_index: Some(self.enumeration_index),
+        }
+    }
+
+    fn from_proto(proto: Self::ProtoStruct) -> Result<Self> {
+        let value_bytes: [u8; 32] = proto.storage_value().try_into()?;
+        Ok(Self {
+            key: U256::from_big_endian(proto.storage_key()),
+            value: StorageValue::from(&value_bytes),
+            miniblock_number_of_initial_write: U64::from(0),
+            l1_batch_number_of_initial_write: proto.l1_batch_number_of_initial_write().into(),
+            enumeration_index: proto.enumeration_index(),
+        })
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct SnapshotFactoryDependencies {
+    pub factory_deps: Vec<SnapshotFactoryDependency>,
+}
+
+impl Proto for SnapshotFactoryDependencies {
+    type ProtoStruct = protobuf::SnapshotFactoryDependencies;
+
+    fn to_proto(&self) -> Self::ProtoStruct {
+        Self::ProtoStruct {
+            factory_deps: self
+                .factory_deps
+                .iter()
+                .map(SnapshotFactoryDependency::to_proto)
+                .collect(),
+        }
+    }
+
+    fn from_proto(proto: Self::ProtoStruct) -> Result<Self> {
+        Ok(Self {
+            factory_deps: proto
+                .factory_deps
+                .into_iter()
+                .map(SnapshotFactoryDependency::from_proto)
+                .collect::<Result<Vec<_>>>()?,
+        })
     }
 }
 
@@ -71,4 +195,22 @@ impl fmt::Display for SnapshotStorageLog {
 pub struct SnapshotFactoryDependency {
     pub bytecode_hash: H256,
     pub bytecode: Vec<u8>,
+}
+
+impl Proto for SnapshotFactoryDependency {
+    type ProtoStruct = protobuf::SnapshotFactoryDependency;
+
+    fn to_proto(&self) -> Self::ProtoStruct {
+        Self::ProtoStruct {
+            bytecode: Some(self.bytecode.clone()),
+        }
+    }
+
+    fn from_proto(proto: Self::ProtoStruct) -> Result<Self> {
+        let bytecode = proto.bytecode();
+        Ok(Self {
+            bytecode_hash: bytecode::hash_bytecode(bytecode),
+            bytecode: bytecode.to_vec(),
+        })
+    }
 }


### PR DESCRIPTION
Introduces a new trait, `Proto`, that defines methods for converting between native structs and ones generated by protobuf, and ones for encoding/decoding those structs into/from gzipped protobuf files.

Notably, `SnapshotStorageLogsChunk` and `SnapshotFactoryDependencies` leverage these methods to simplify the snapshot export/import code further and avoid intermingling structs from `protobuf::*` with `types::*`.