### PR TITLE
ref: use `U256` as key in initial storage changes

### DIFF
--- a/src/processor/snapshot/exporter.rs
+++ b/src/processor/snapshot/exporter.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use ethers::types::U64;
+use ethers::types::{U256, U64};
 use eyre::Result;
 
 use super::{
@@ -105,7 +105,8 @@ impl SnapshotExporter {
             let mut chunk = SnapshotStorageLogsChunk::default();
             for _ in 0..chunk_size {
                 if let Some(Ok((_, key))) = iterator.next() {
-                    if let Ok(Some(entry)) = self.database.get_storage_log(key.as_ref()) {
+                    let key = U256::from_big_endian(&key);
+                    if let Ok(Some(entry)) = self.database.get_storage_log(&key) {
                         chunk.storage_logs.push(entry);
                     }
                 } else {

--- a/src/processor/tree/tree_wrapper.rs
+++ b/src/processor/tree/tree_wrapper.rs
@@ -64,15 +64,14 @@ impl TreeWrapper {
         let mut index =
             block.index_repeated_storage_changes - (block.initial_storage_changes.len() as u64);
         for (key, value) in &block.initial_storage_changes {
-            let key = U256::from_little_endian(key);
-            self.insert_known_key(index, key);
-            let value = self.process_value(key, *value);
+            self.insert_known_key(index, *key);
+            let value = self.process_value(*key, *value);
 
-            tree_entries.push(TreeEntry::new(key, index, value));
+            tree_entries.push(TreeEntry::new(*key, index, value));
             self.snapshot
                 .lock()
                 .await
-                .add_key(&key)
+                .add_key(key)
                 .expect("cannot add key");
             index += 1;
         }

--- a/state-reconstruct-fetcher/src/types/mod.rs
+++ b/state-reconstruct-fetcher/src/types/mod.rs
@@ -87,7 +87,7 @@ pub struct CommitBlock {
     pub new_state_root: Vec<u8>,
     /// Storage write access as a concatenation key-value.
     #[serde(with = "any_key_map")]
-    pub initial_storage_changes: IndexMap<[u8; 32], PackingType>,
+    pub initial_storage_changes: IndexMap<U256, PackingType>,
     /// Storage write access as a concatenation index-value.
     #[serde(with = "any_key_map")]
     pub repeated_storage_changes: IndexMap<u64, PackingType>,
@@ -144,13 +144,10 @@ impl CommitBlock {
                             derived_key,
                             packing_type,
                         } => {
-                            let mut key = [0u8; 32];
-                            derived_key.to_big_endian(&mut key);
-
                             if is_repeated_write {
                                 repeated_storage_changes.insert(derived_key.as_u64(), packing_type);
                             } else {
-                                initial_storage_changes.insert(key, packing_type);
+                                initial_storage_changes.insert(derived_key, packing_type);
                             };
                         }
                     }
@@ -186,13 +183,10 @@ impl CommitBlock {
                     derived_key,
                     packing_type,
                 } => {
-                    let mut key = [0u8; 32];
-                    derived_key.to_big_endian(&mut key);
-
                     if is_repeated_write {
                         repeated_storage_changes.insert(derived_key.as_u64(), packing_type);
                     } else {
-                        initial_storage_changes.insert(key, packing_type);
+                        initial_storage_changes.insert(derived_key, packing_type);
                     };
                 }
             }

--- a/state-reconstruct-fetcher/src/types/v1.rs
+++ b/state-reconstruct-fetcher/src/types/v1.rs
@@ -24,7 +24,7 @@ pub struct V1 {
     pub priority_operations_hash: Vec<u8>,
     /// Storage write access as a concatenation key-value.
     #[serde(with = "any_key_map")]
-    pub initial_storage_changes: IndexMap<[u8; 32], [u8; 32]>,
+    pub initial_storage_changes: IndexMap<U256, [u8; 32]>,
     /// Storage write access as a concatenation index-value.
     #[serde(with = "any_key_map")]
     pub repeated_storage_changes: IndexMap<u64, [u8; 32]>,
@@ -111,6 +111,7 @@ impl TryFrom<&abi::Token> for V1 {
                 ));
             }
 
+            let key = U256::from_little_endian(&key);
             let _ = blk.initial_storage_changes.insert(key, value);
         }
 


### PR DESCRIPTION
- Changes a few signatures to use the processed type (`U256`) over the raw bytes, lessening the use of byte conversion we have to do manually.