### PR TITLE
feat: import snapshots without header file present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4451,6 +4451,7 @@ dependencies = [
  "hex",
  "indexmap",
  "primitive-types",
+ "regex",
  "rocksdb",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ eyre = "0.6.8"
 hex = "0.4.3"
 indexmap = { version = "2.0.2" }
 primitive-types = "0.12.2"
+regex = "1.10.4"
 rocksdb = "0.21"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = { version = "1.0.107", features = ["std"] }


### PR DESCRIPTION
* Enables importing snapshot without reliance on a header file. If a snapshot header file is not found within the specified snapshot folder, the importer will instead try to generate one using the filenames of the other contents as a base.
* Adjusts the importing process to extend the tree each chunk instead of after all have been collected. This alleviates an issues wherein trying to recover from large snapshots could trigger warning signals to the shell and be sent `SIGKILL` forcefully as a result.