### PR TITLE
tweak: higher `BLOCK_STEP`

### DIFF
--- a/state-reconstruct-fetcher/src/constants.rs
+++ b/state-reconstruct-fetcher/src/constants.rs
@@ -1,6 +1,6 @@
 pub mod ethereum {
     /// Number of Ethereum blocks to advance in one filter step.
-    pub const BLOCK_STEP: u64 = 128;
+    pub const BLOCK_STEP: u64 = 10_000;
 
     /// Block number in Ethereum for zkSync genesis block.
     pub const GENESIS_BLOCK: u64 = 16_627_460;


### PR DESCRIPTION
The previous value of `128` uses up a lot of RPC-calls for very little actual benefit, and in some cases it even makes the tool run slower when ran with unreliable RPC-providers.