### PR TITLE
docker: update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rustlang/rust:nightly-bookworm-slim
+FROM debian:bookworm-slim
 
 RUN set -eux; \
     apt-get update; \
@@ -6,24 +6,27 @@ RUN set -eux; \
         build-essential \
         libclang-dev \
         libssl-dev \
-        pkg-config
+        pkg-config \
+        openssl \
+        protobuf-compiler \
+        ca-certificates \
+        curl
 
-COPY ./src ./src
+COPY src/ src/
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
+COPY rust-toolchain.toml rust-toolchain.toml
+
+COPY state-reconstruct-fetcher/ state-reconstruct-fetcher/
+COPY state-reconstruct-storage/ state-reconstruct-storage/
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN cargo build --release
+ENV PATH="/target/release:${PATH}"
 
-FROM debian:bookworm-slim
-
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        openssl
-
-COPY --from=0 ./target/release/state-reconstruct /state-reconstruct
-COPY IZkSync.json IZkSync.json
+COPY abi/ abi/
 COPY InitialState.csv InitialState.csv
 
-CMD ["/state-reconstruct", "reconstruct", "l1", "--http-url", "https://eth.llamarpc.com"]
+CMD ["state-reconstruct", "reconstruct", "l1", "--http-url", "https://eth.llamarpc.com"]


### PR DESCRIPTION
- Adds missing dependencies.
- Installs Rust via `rustup` (so we can use the version specified in `.rust-toolchain.toml`).