### PR TITLE
chore: adhere new naming conventions

### DIFF
--- a/src/processor/snapshot/exporter.rs
+++ b/src/processor/snapshot/exporter.rs
@@ -36,20 +36,16 @@ impl SnapshotExporter {
     }
 
     pub fn export_snapshot(&self, num_chunks: usize) -> Result<()> {
-        let l2_batch_number = self
+        let l1_batch_number = self
             .database
-            .get_latest_l2_batch_number()?
-            .ok_or_eyre("no latest l2 batch number in snapshot db")?;
+            .get_latest_l1_batch_number()?
+            .ok_or_eyre("no latest l1 batch number in snapshot db")?;
         let l2_block_number = self.database.get_latest_l2_block_number()?.unwrap_or({
             tracing::warn!("WARNING: the database contains no l2 block number entry and will not be compatible with the ZKSync External Node! To export a compatible snapshot, please let the prepare-snapshot command run until an l2 block number can be found.");
             U64::from(0)
         });
         let mut header = SnapshotHeader {
-            // NOTE: `l1_batch_number` in the snapshot header actually refers
-            // to the ZKsync batch number and not the Ethereum batch height we
-            // store in the snapshot database. In the snapshot database this
-            // field is referred to as `l2_batch_number`.
-            l1_batch_number: l2_batch_number.as_u64(),
+            l1_batch_number: l1_batch_number.as_u64(),
             miniblock_number: l2_block_number.as_u64(),
             ..Default::default()
         };

--- a/src/processor/snapshot/mod.rs
+++ b/src/processor/snapshot/mod.rs
@@ -56,7 +56,7 @@ impl SnapshotBuilder {
     // Gets the next L1 batch number to be processed for ues in state recovery.
     pub fn get_latest_l1_batch_number(&self) -> Result<U64> {
         self.database
-            .get_latest_l1_batch_number()
+            .get_latest_l1_block_number()
             .map(|o| o.unwrap_or(U64::from(0)))
     }
 }
@@ -133,10 +133,10 @@ impl Processor for SnapshotBuilder {
 
             let _ = self
                 .database
-                .set_latest_l2_block_number(block.l2_block_number);
+                .set_latest_l2_block_number(block.l1_batch_number);
 
             if let Some(number) = block.l1_block_number {
-                let _ = self.database.set_latest_l1_batch_number(number);
+                let _ = self.database.set_latest_l1_block_number(number);
             };
         }
     }
@@ -273,7 +273,7 @@ mod tests {
                 let repeated_storage_changes = IndexMap::new();
                 let cb = CommitBlock {
                     l1_block_number: Some(1),
-                    l2_block_number: 2,
+                    l1_batch_number: 2,
                     index_repeated_storage_changes: 0,
                     new_state_root: Vec::new(),
                     initial_storage_changes,

--- a/src/processor/tree/mod.rs
+++ b/src/processor/tree/mod.rs
@@ -65,16 +65,16 @@ impl Processor for TreeProcessor {
         let mut snapshot_metric = PerfMetric::new("snapshot");
         while let Some(block) = rx.recv().await {
             // Check if we've already processed this block.
-            let latest_l2 = self
+            let latest_l1_batch = self
                 .inner_db
                 .lock()
                 .await
-                .get_latest_l2_batch_number()
+                .get_latest_l1_batch_number()
                 .expect("value should default to 0");
-            if latest_l2 >= block.l2_block_number {
+            if latest_l1_batch >= block.l1_batch_number {
                 tracing::debug!(
-                    "Block {} has already been processed, skipping.",
-                    block.l2_block_number
+                    "Batch {} has already been processed, skipping.",
+                    block.l1_batch_number
                 );
                 continue;
             }
@@ -92,7 +92,7 @@ impl Processor for TreeProcessor {
             self.inner_db
                 .lock()
                 .await
-                .set_latest_l2_batch_number(block.l2_block_number)
+                .set_latest_l1_batch_number(block.l1_batch_number)
                 .expect("db failed");
 
             if snapshot_metric.add(before.elapsed()) > 10 {

--- a/src/processor/tree/tree_wrapper.rs
+++ b/src/processor/tree/tree_wrapper.rs
@@ -107,14 +107,14 @@ impl TreeWrapper {
         let root_hash = output.root_hash;
 
         tracing::debug!(
-            "Root hash of block {} = {}",
-            block.l2_block_number,
+            "Root hash of batch {} = {}",
+            block.l1_batch_number,
             hex::encode(root_hash)
         );
 
         let root_hash_bytes = root_hash.as_bytes();
         if root_hash_bytes == block.new_state_root {
-            tracing::debug!("Successfully processed block {}", block.l2_block_number);
+            tracing::debug!("Successfully processed batch {}", block.l1_batch_number);
 
             Ok(root_hash)
         } else {

--- a/state-reconstruct-fetcher/src/metrics.rs
+++ b/state-reconstruct-fetcher/src/metrics.rs
@@ -7,13 +7,13 @@ pub const METRICS_TRACING_TARGET: &str = "metrics";
 pub struct L1Metrics {
     /// The first L1 block fetched.
     pub first_l1_block_num: u64,
-    /// The first L2 block fetched.
-    pub first_l2_block_num: u64,
+    /// The first L2 batch fetched.
+    pub first_l1_batch_num: u64,
 
     /// The latest L1 block fetched.
     pub latest_l1_block_num: u64,
     /// The latest L2 block fetched.
-    pub latest_l2_block_num: u64,
+    pub latest_l1_batch_num: u64,
 
     /// The first L1 block to compare against when measuring progress.
     pub initial_l1_block: u64,
@@ -32,9 +32,9 @@ impl L1Metrics {
     pub fn new(initial_l1_block: u64) -> Self {
         L1Metrics {
             first_l1_block_num: 0,
-            first_l2_block_num: 0,
+            first_l1_batch_num: 0,
             latest_l1_block_num: 0,
-            latest_l2_block_num: 0,
+            latest_l1_batch_num: 0,
             initial_l1_block,
             last_l1_block: 0,
             log_acquisition: PerfMetric::new("log_acquisition"),
@@ -62,13 +62,13 @@ impl L1Metrics {
         };
 
         tracing::info!(
-            "PROGRESS: [{}] CUR BLOCK L1: {} L2: {} TOTAL BLOCKS PROCESSED L1: {} L2: {}",
+            "PROGRESS: [{}] CUR L1 BLOCK: {} L2 BATCH: {} TOTAL PROCESSED L1 BLOCKS: {} L2 BATCHES: {}",
             progress,
             self.latest_l1_block_num,
-            self.latest_l2_block_num,
+            self.latest_l1_batch_num,
             self.latest_l1_block_num - self.first_l1_block_num,
-            self.latest_l2_block_num
-                .saturating_sub(self.first_l2_block_num)
+            self.latest_l1_batch_num
+                .saturating_sub(self.first_l1_batch_num)
         );
 
         let log_acquisition = self.log_acquisition.reset();

--- a/state-reconstruct-fetcher/src/types/common.rs
+++ b/state-reconstruct-fetcher/src/types/common.rs
@@ -8,7 +8,7 @@ use crate::constants::zksync::{
 };
 
 pub struct ExtractedToken {
-    pub new_l2_block_number: U256,
+    pub l1_batch_number: U256,
     pub timestamp: U256,
     pub new_enumeration_index: U256,
     pub state_root: Vec<u8>,
@@ -30,7 +30,7 @@ impl TryFrom<&abi::Token> for ExtractedToken {
             ));
         };
 
-        let abi::Token::Uint(new_l2_block_number) = block_elems[0].clone() else {
+        let abi::Token::Uint(l1_batch_number) = block_elems[0].clone() else {
             return Err(ParseError::InvalidCommitBlockInfo(
                 "blockNumber".to_string(),
             ));
@@ -75,7 +75,7 @@ impl TryFrom<&abi::Token> for ExtractedToken {
         };
 
         Ok(Self {
-            new_l2_block_number,
+            l1_batch_number,
             timestamp,
             new_enumeration_index,
             state_root,

--- a/state-reconstruct-fetcher/src/types/mod.rs
+++ b/state-reconstruct-fetcher/src/types/mod.rs
@@ -68,11 +68,11 @@ pub enum CommitBlockInfo {
 /// Block with all required fields extracted from a [`CommitBlockInfo`].
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CommitBlock {
-    /// L1 block number.
+    /// Ethereum block number.
     #[serde(skip)]
     pub l1_block_number: Option<u64>,
-    /// L2 block number.
-    pub l2_block_number: u64,
+    /// ZKSync batch number.
+    pub l1_batch_number: u64,
     /// Next unused key serial number.
     pub index_repeated_storage_changes: u64,
     /// The state root of the full state tree.
@@ -108,7 +108,7 @@ impl CommitBlock {
         match block_type {
             CommitBlockInfo::V1(block) => CommitBlock {
                 l1_block_number: None,
-                l2_block_number: block.block_number,
+                l1_batch_number: block.l1_batch_number,
                 index_repeated_storage_changes: block.index_repeated_storage_changes,
                 new_state_root: block.new_state_root,
                 initial_storage_changes: block
@@ -147,7 +147,7 @@ impl CommitBlock {
 
                 CommitBlock {
                     l1_block_number: None,
-                    l2_block_number: block.block_number,
+                    l1_batch_number: block.l1_batch_number,
                     index_repeated_storage_changes: block.index_repeated_storage_changes,
                     new_state_root: block.new_state_root,
                     initial_storage_changes,
@@ -186,7 +186,7 @@ impl CommitBlock {
 
         Ok(CommitBlock {
             l1_block_number: None,
-            l2_block_number: block.block_number,
+            l1_batch_number: block.l1_batch_number,
             index_repeated_storage_changes: block.index_repeated_storage_changes,
             new_state_root: block.new_state_root,
             initial_storage_changes,

--- a/state-reconstruct-fetcher/src/types/v1.rs
+++ b/state-reconstruct-fetcher/src/types/v1.rs
@@ -8,8 +8,8 @@ use super::{CommitBlockFormat, CommitBlockInfo, ParseError};
 /// Data needed to commit new block
 #[derive(Debug, Serialize, Deserialize)]
 pub struct V1 {
-    /// L2 block number.
-    pub block_number: u64,
+    /// ZKSync batch number.
+    pub l1_batch_number: u64,
     /// Unix timestamp denoting the start of the block execution.
     pub timestamp: u64,
     /// The serial number of the shortcut index that's used as a unique identifier for storage keys that were used twice or more.
@@ -46,7 +46,7 @@ impl TryFrom<&abi::Token> for V1 {
     /// Try to parse Ethereum ABI token into [`V1`].
     fn try_from(token: &abi::Token) -> Result<Self, Self::Error> {
         let ExtractedToken {
-            new_l2_block_number,
+            l1_batch_number,
             timestamp,
             new_enumeration_index,
             state_root,
@@ -83,7 +83,7 @@ impl TryFrom<&abi::Token> for V1 {
         );
 
         let mut blk = V1 {
-            block_number: new_l2_block_number.as_u64(),
+            l1_batch_number: l1_batch_number.as_u64(),
             timestamp: timestamp.as_u64(),
             index_repeated_storage_changes: new_enumeration_index,
             new_state_root: state_root,
@@ -145,7 +145,7 @@ impl TryFrom<&abi::Token> for V1 {
 }
 
 struct ExtractedToken {
-    new_l2_block_number: U256,
+    l1_batch_number: U256,
     timestamp: U256,
     new_enumeration_index: U256,
     state_root: Vec<u8>,
@@ -168,7 +168,7 @@ impl TryFrom<&abi::Token> for ExtractedToken {
             ));
         };
 
-        let abi::Token::Uint(new_l2_block_number) = block_elems[0].clone() else {
+        let abi::Token::Uint(l1_batch_number) = block_elems[0].clone() else {
             return Err(ParseError::InvalidCommitBlockInfo(
                 "blockNumber".to_string(),
             ));
@@ -247,7 +247,7 @@ impl TryFrom<&abi::Token> for ExtractedToken {
         };
 
         Ok(Self {
-            new_l2_block_number,
+            l1_batch_number,
             timestamp,
             new_enumeration_index,
             state_root,

--- a/state-reconstruct-fetcher/src/types/v2.rs
+++ b/state-reconstruct-fetcher/src/types/v2.rs
@@ -9,8 +9,8 @@ use super::{
 /// Data needed to commit new block
 #[derive(Debug, Serialize, Deserialize)]
 pub struct V2 {
-    /// L2 block number.
-    pub block_number: u64,
+    /// ZKSync batch number.
+    pub l1_batch_number: u64,
     /// Unix timestamp denoting the start of the block execution.
     pub timestamp: u64,
     /// The serial number of the shortcut index that's used as a unique identifier for storage keys that were used twice or more.
@@ -39,7 +39,7 @@ impl TryFrom<&abi::Token> for V2 {
     /// Try to parse Ethereum ABI token into [`V2`].
     fn try_from(token: &abi::Token) -> Result<Self, Self::Error> {
         let ExtractedToken {
-            new_l2_block_number,
+            l1_batch_number,
             timestamp,
             new_enumeration_index,
             state_root,
@@ -52,7 +52,7 @@ impl TryFrom<&abi::Token> for V2 {
 
         let total_l2_to_l1_pubdata = parse_resolved_pubdata(&total_l2_to_l1_pubdata)?;
         let blk = V2 {
-            block_number: new_l2_block_number.as_u64(),
+            l1_batch_number: l1_batch_number.as_u64(),
             timestamp: timestamp.as_u64(),
             index_repeated_storage_changes: new_enumeration_index,
             new_state_root: state_root,

--- a/state-reconstruct-fetcher/src/types/v3.rs
+++ b/state-reconstruct-fetcher/src/types/v3.rs
@@ -38,8 +38,8 @@ impl TryFrom<u8> for PubdataSource {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct V3 {
     pub pubdata_source: PubdataSource,
-    /// L2 block number.
-    pub block_number: u64,
+    /// ZKSync batch number
+    pub l1_batch_number: u64,
     /// Unix timestamp denoting the start of the block execution.
     pub timestamp: u64,
     /// The serial number of the shortcut index that's used as a unique identifier for storage keys that were used twice or more.
@@ -64,7 +64,7 @@ impl TryFrom<&abi::Token> for V3 {
     /// * `token` - ABI token of `CommitBlockInfo` type on Ethereum.
     fn try_from(token: &abi::Token) -> Result<Self, Self::Error> {
         let ExtractedToken {
-            new_l2_block_number,
+            l1_batch_number,
             timestamp,
             new_enumeration_index,
             state_root,
@@ -81,7 +81,7 @@ impl TryFrom<&abi::Token> for V3 {
             total_l2_to_l1_pubdata[pointer..total_l2_to_l1_pubdata.len()].to_vec();
         let blk = V3 {
             pubdata_source,
-            block_number: new_l2_block_number.as_u64(),
+            l1_batch_number: l1_batch_number.as_u64(),
             timestamp: timestamp.as_u64(),
             index_repeated_storage_changes: new_enumeration_index,
             new_state_root: state_root,

--- a/state-reconstruct-storage/src/lib.rs
+++ b/state-reconstruct-storage/src/lib.rs
@@ -14,9 +14,10 @@ pub const METADATA: &str = "metadata";
 pub mod reconstruction_columns {
     pub const LAST_REPEATED_KEY_INDEX: &str = "LAST_REPEATED_KEY_INDEX";
     /// The latest l1 block number that was processed.
-    pub const LATEST_L1_BATCH: &str = "LATEST_L1_BLOCK_NUMBER";
-    /// The latest l2 block number that was processed.
-    pub const LATEST_L2_BATCH: &str = "LATEST_L2_BLOCK_NUMBER";
+    pub const LATEST_L1_BLOCK: &str = "LATEST_L1_BLOCK_NUMBER";
+    /// The latest l1 batch number that was processed. This is the batch number
+    /// of the ZKSync transactions.
+    pub const LATEST_L1_BATCH: &str = "LATEST_L1_BATCH_NUMBER";
 }
 
 pub mod snapshot_columns {
@@ -24,9 +25,10 @@ pub mod snapshot_columns {
     pub const FACTORY_DEPS: &str = "factory_deps";
 
     pub const LAST_REPEATED_KEY_INDEX: &str = "SNAPSHOT_LAST_REPEATED_KEY_INDEX";
-    /// The latest l1 batch number that was processed.
-    pub const LATEST_L1_BATCH: &str = "SNAPSHOT_LATEST_L1_BATCH";
-    /// The latest l2 batch number that was processed.
+    /// The latest l1 block number that was processed.
+    pub const LATEST_L1_BLOCK: &str = "SNAPSHOT_LATEST_L1_BLOCK";
+    /// The latest l1 batch number that was processed. This is the batch number
+    /// of the ZKSync transactions.
     pub const LATEST_L2_BATCH: &str = "SNAPSHOT_LATEST_L2_BATCH";
     /// The latest l2 block number that was processed.
     pub const LATEST_L2_BLOCK: &str = "SNAPSHOT_LATEST_L2_BLOCK";

--- a/state-reconstruct-storage/src/reconstruction.rs
+++ b/state-reconstruct-storage/src/reconstruction.rs
@@ -32,21 +32,21 @@ impl ReconstructionDatabase {
         Ok(Self(db))
     }
 
-    pub fn get_latest_l1_batch_number(&self) -> Result<U64> {
-        self.get_metadata_value(reconstruction_columns::LATEST_L1_BATCH)
+    pub fn get_latest_l1_block_number(&self) -> Result<U64> {
+        self.get_metadata_value(reconstruction_columns::LATEST_L1_BLOCK)
             .map(U64::from)
+    }
+
+    pub fn set_latest_l1_block_number(&self, number: u64) -> Result<()> {
+        self.set_metadata_value(reconstruction_columns::LATEST_L1_BLOCK, number)
+    }
+
+    pub fn get_latest_l1_batch_number(&self) -> Result<u64> {
+        self.get_metadata_value(reconstruction_columns::LATEST_L1_BATCH)
     }
 
     pub fn set_latest_l1_batch_number(&self, number: u64) -> Result<()> {
         self.set_metadata_value(reconstruction_columns::LATEST_L1_BATCH, number)
-    }
-
-    pub fn get_latest_l2_batch_number(&self) -> Result<u64> {
-        self.get_metadata_value(reconstruction_columns::LATEST_L2_BATCH)
-    }
-
-    pub fn set_latest_l2_batch_number(&self, number: u64) -> Result<()> {
-        self.set_metadata_value(reconstruction_columns::LATEST_L2_BATCH, number)
     }
 
     pub fn get_last_repeated_key_index(&self) -> Result<u64> {

--- a/state-reconstruct-storage/src/snapshot.rs
+++ b/state-reconstruct-storage/src/snapshot.rs
@@ -36,7 +36,7 @@ impl SnapshotDatabase {
                 KEY_TO_INDEX_MAP,
                 snapshot_columns::STORAGE_LOGS,
                 snapshot_columns::FACTORY_DEPS,
-                snapshot_columns::LATEST_L1_BATCH,
+                snapshot_columns::LATEST_L1_BLOCK,
                 snapshot_columns::LATEST_L2_BATCH,
                 snapshot_columns::LATEST_L2_BLOCK,
             ],
@@ -59,7 +59,7 @@ impl SnapshotDatabase {
                 KEY_TO_INDEX_MAP,
                 snapshot_columns::STORAGE_LOGS,
                 snapshot_columns::FACTORY_DEPS,
-                snapshot_columns::LATEST_L1_BATCH,
+                snapshot_columns::LATEST_L1_BLOCK,
                 snapshot_columns::LATEST_L2_BATCH,
                 snapshot_columns::LATEST_L2_BLOCK,
             ],
@@ -156,21 +156,21 @@ impl SnapshotDatabase {
             .map_err(Into::into)
     }
 
-    pub fn get_latest_l1_batch_number(&self) -> Result<Option<U64>> {
-        self.get_metadata_value(snapshot_columns::LATEST_L1_BATCH)
+    pub fn get_latest_l1_block_number(&self) -> Result<Option<U64>> {
+        self.get_metadata_value(snapshot_columns::LATEST_L1_BLOCK)
             .map(|o| o.map(U64::from))
     }
 
-    pub fn set_latest_l1_batch_number(&self, number: u64) -> Result<()> {
-        self.set_metadata_value(snapshot_columns::LATEST_L1_BATCH, number)
+    pub fn set_latest_l1_block_number(&self, number: u64) -> Result<()> {
+        self.set_metadata_value(snapshot_columns::LATEST_L1_BLOCK, number)
     }
 
-    pub fn get_latest_l2_batch_number(&self) -> Result<Option<U64>> {
+    pub fn get_latest_l1_batch_number(&self) -> Result<Option<U64>> {
         self.get_metadata_value(snapshot_columns::LATEST_L2_BATCH)
             .map(|o| o.map(U64::from))
     }
 
-    pub fn set_latest_l2_batch_number(&self, number: u64) -> Result<()> {
+    pub fn set_latest_l1_batch_number(&self, number: u64) -> Result<()> {
         self.set_metadata_value(snapshot_columns::LATEST_L2_BATCH, number)
     }
 


### PR DESCRIPTION
The new naming convention is as follows:
- L1 block number - The Ethereum block height of the published batch.
- L1 batch number - The number of the ZKSync batch.
- L2 block number - The legacy number of the ZKSync batch (formerly known as miniblock).