### PR TITLE
feat: map l1 batch numbers to their l1 block number equivalent

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,9 +109,6 @@ pub enum Command {
         /// The path to the storage solution.
         #[arg(short, long, default_value = snapshot::DEFAULT_DB_PATH)]
         db_path: Option<String>,
-        /// Number of chunks to split storage chunks into.
-        #[arg(short, long, default_value_t = snapshot::DEFAULT_NUM_CHUNKS)]
-        num_chunks: usize,
         /// The directory to export the snapshot files to.
         directory: String,
     },

--- a/src/processor/snapshot/exporter.rs
+++ b/src/processor/snapshot/exporter.rs
@@ -112,7 +112,6 @@ impl SnapshotExporter {
             .iterator_cf(index_to_key_map, rocksdb::IteratorMode::Start);
 
         let num_chunks = num_logs.div_ceil(SNAPSHOT_CHUNK_SIZE as u64);
-        println!("{num_chunks}");
         for chunk_id in 0..num_chunks {
             tracing::info!("Serializing chunk {}/{}...", chunk_id + 1, num_chunks);
 

--- a/src/processor/snapshot/exporter.rs
+++ b/src/processor/snapshot/exporter.rs
@@ -111,7 +111,8 @@ impl SnapshotExporter {
             .database
             .iterator_cf(index_to_key_map, rocksdb::IteratorMode::Start);
 
-        let num_chunks = (num_logs / SNAPSHOT_CHUNK_SIZE as u64) + 1;
+        let num_chunks = num_logs.div_ceil(SNAPSHOT_CHUNK_SIZE as u64);
+        println!("{num_chunks}");
         for chunk_id in 0..num_chunks {
             tracing::info!("Serializing chunk {}/{}...", chunk_id + 1, num_chunks);
 

--- a/src/processor/snapshot/exporter.rs
+++ b/src/processor/snapshot/exporter.rs
@@ -16,6 +16,9 @@ use crate::processor::snapshot::{
     DEFAULT_DB_PATH, SNAPSHOT_FACTORY_DEPS_FILE_NAME_SUFFIX, SNAPSHOT_HEADER_FILE_NAME,
 };
 
+/// Number of storage logs included in each chunk.
+const SNAPSHOT_CHUNK_SIZE: usize = 1_000_000;
+
 pub struct SnapshotExporter {
     basedir: PathBuf,
     database: SnapshotDatabase,
@@ -35,7 +38,7 @@ impl SnapshotExporter {
         })
     }
 
-    pub fn export_snapshot(&self, num_chunks: usize) -> Result<()> {
+    pub fn export_snapshot(&self) -> Result<()> {
         let l1_batch_number = self
             .database
             .get_latest_l1_batch_number()?
@@ -50,7 +53,7 @@ impl SnapshotExporter {
             ..Default::default()
         };
 
-        self.export_storage_logs(num_chunks, &mut header)?;
+        self.export_storage_logs(&mut header)?;
         self.export_factory_deps(&mut header)?;
 
         let path = self.basedir.join(SNAPSHOT_HEADER_FILE_NAME);
@@ -97,7 +100,7 @@ impl SnapshotExporter {
         Ok(())
     }
 
-    fn export_storage_logs(&self, num_chunks: usize, header: &mut SnapshotHeader) -> Result<()> {
+    fn export_storage_logs(&self, header: &mut SnapshotHeader) -> Result<()> {
         tracing::info!("Exporting storage logs...");
 
         let num_logs = self.database.get_last_repeated_key_index()?;
@@ -108,17 +111,17 @@ impl SnapshotExporter {
             .database
             .iterator_cf(index_to_key_map, rocksdb::IteratorMode::Start);
 
-        let chunk_size = num_logs / num_chunks as u64;
+        let num_chunks = (num_logs / SNAPSHOT_CHUNK_SIZE as u64) + 1;
         for chunk_id in 0..num_chunks {
             tracing::info!("Serializing chunk {}/{}...", chunk_id + 1, num_chunks);
 
             let mut chunk = SnapshotStorageLogsChunk::default();
-            for _ in 0..chunk_size {
+            for _ in 0..SNAPSHOT_CHUNK_SIZE {
                 if let Some(Ok((_, key))) = iterator.next() {
                     let key = U256::from_big_endian(&key);
                     if let Ok(Some(entry)) = self.database.get_storage_log(&key) {
                         chunk.storage_logs.push(entry);
-                    }
+                    };
                 } else {
                     break;
                 }
@@ -131,7 +134,7 @@ impl SnapshotExporter {
             header
                 .storage_logs_chunks
                 .push(SnapshotStorageLogsChunkMetadata {
-                    chunk_id: chunk_id as u64,
+                    chunk_id,
                     filepath: path
                         .clone()
                         .into_os_string()

--- a/src/processor/snapshot/mod.rs
+++ b/src/processor/snapshot/mod.rs
@@ -25,7 +25,6 @@ use crate::util::{h256_to_u256, unpack_block_info};
 pub const DEFAULT_DB_PATH: &str = "snapshot_db";
 pub const SNAPSHOT_HEADER_FILE_NAME: &str = "snapshot-header.json";
 pub const SNAPSHOT_FACTORY_DEPS_FILE_NAME_SUFFIX: &str = "factory_deps.proto.gzip";
-pub const DEFAULT_NUM_CHUNKS: usize = 10;
 
 pub struct SnapshotBuilder {
     database: SnapshotDatabase,
@@ -53,8 +52,8 @@ impl SnapshotBuilder {
         Self { database }
     }
 
-    // Gets the next L1 batch number to be processed for ues in state recovery.
-    pub fn get_latest_l1_batch_number(&self) -> Result<U64> {
+    // Gets the next L1 block number to be processed for ues in state recovery.
+    pub fn get_latest_l1_block_number(&self) -> Result<U64> {
         self.database
             .get_latest_l1_block_number()
             .map(|o| o.unwrap_or(U64::from(0)))
@@ -107,7 +106,7 @@ impl Processor for SnapshotBuilder {
 
                 if self
                     .database
-                    .update_storage_log_value(index as u64, &value.to_fixed_bytes())
+                    .update_storage_log_value(index as u64, value)
                     .is_err()
                 {
                     let max_idx = self

--- a/src/processor/tree/tree_wrapper.rs
+++ b/src/processor/tree/tree_wrapper.rs
@@ -168,18 +168,21 @@ impl TreeWrapper {
             total_tree_entries += tree_entries.len();
             self.tree.extend(tree_entries);
 
-            tracing::info!("Chunk {} was succesfully imported!", i + 1);
+            tracing::info!("Chunk {} was successfully imported!", i + 1);
             i += 1;
         }
 
         tracing::info!(
-            "Succesfully imported snapshot containing {total_tree_entries} storage logs!",
+            "Successfully imported snapshot containing {total_tree_entries} storage logs!",
         );
+
+        let root_hash = hex::encode(self.tree.latest_root_hash());
+        tracing::debug!("Current root hash is: {}", root_hash);
 
         self.inner_db
             .lock()
             .await
-            .set_latest_l1_batch_number(l1_batch_number.as_u64() + 1)?;
+            .set_latest_l1_batch_number(l1_batch_number.as_u64())?;
 
         Ok(())
     }

--- a/state-reconstruct-fetcher/src/metrics.rs
+++ b/state-reconstruct-fetcher/src/metrics.rs
@@ -62,7 +62,7 @@ impl L1Metrics {
         };
 
         tracing::info!(
-            "PROGRESS: [{}] CUR L1 BLOCK: {} L2 BATCH: {} TOTAL PROCESSED L1 BLOCKS: {} L2 BATCHES: {}",
+            "PROGRESS: [{}] CUR L1 BLOCK: {} L1 BATCH: {} TOTAL PROCESSED L1 BLOCKS: {} L1 BATCHES: {}",
             progress,
             self.latest_l1_block_num,
             self.latest_l1_batch_num,

--- a/state-reconstruct-storage/src/types.rs
+++ b/state-reconstruct-storage/src/types.rs
@@ -169,7 +169,7 @@ impl Proto for SnapshotStorageLog {
     fn from_proto(proto: Self::ProtoStruct) -> Result<Self> {
         let value_bytes: [u8; 32] = proto.storage_value().try_into()?;
         Ok(Self {
-            key: U256::from_big_endian(proto.storage_key()),
+            key: U256::from_big_endian(proto.hashed_key()),
             value: StorageValue::from(&value_bytes),
             l1_batch_number_of_initial_write: proto.l1_batch_number_of_initial_write().into(),
             enumeration_index: proto.enumeration_index(),


### PR DESCRIPTION
- Adds a mapping function to L1 fetcher that takes in any L1 batch number and tries to find its corresponding L1 block number by using binary search on fetched logs.
- Removes `num_chunks` argument. We now use the default chunk size of `1_000_000` to calculate how many chunks we need instead.
- Fixes some smaller miscellaneous issues with the snapshots